### PR TITLE
feat: Add automated wiki sync workflow

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,47 @@
+name: Sync Wiki
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'wiki/**'
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Checkout wiki repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki-repo
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Sync wiki files
+        run: |
+          echo "📚 Syncing wiki pages from main repo to wiki..."
+          rsync -av --delete --exclude='.git' wiki/ wiki-repo/
+          
+      - name: Commit and push changes
+        working-directory: wiki-repo
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          
+          if git diff --cached --quiet; then
+            echo "✅ No changes to sync"
+          else
+            git commit -m "Auto-sync from main repo
+
+Synced at $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+Source commit: ${{ github.sha }}"
+            git push origin master
+            echo "✅ Wiki published successfully!"
+          fi

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -38,10 +38,11 @@ jobs:
           if git diff --cached --quiet; then
             echo "✅ No changes to sync"
           else
-            git commit -m "Auto-sync from main repo
+            COMMIT_MSG="Auto-sync from main repo
 
 Synced at $(date -u '+%Y-%m-%d %H:%M:%S UTC')
 Source commit: ${{ github.sha }}"
+            git commit -m "$COMMIT_MSG"
             git push origin master
             echo "✅ Wiki published successfully!"
           fi


### PR DESCRIPTION
## 🎯 What This PR Does

Adds GitHub Action to automatically sync wiki content from main repo to GitHub wiki.

## ✨ Features

- **Auto-sync**: Triggers on every push to main when wiki/** files change
- **Manual trigger**: Can be run manually via workflow_dispatch
- **Smart commits**: Only commits if there are actual changes
- **Proper attribution**: Uses github-actions[bot] for commits

## 🔄 Workflow

1. Developer edits wiki pages in `chimera/wiki/` directory
2. Push to main (via PR merge)
3. GitHub Action automatically syncs to wiki repository
4. Wiki pages instantly updated at https://github.com/ArrEssJay/chimera/wiki

## 📋 Benefits

- **Single source of truth**: Wiki content lives in main repo
- **Version controlled**: All wiki changes tracked in git history
- **PR review**: Wiki changes go through same review process as code
- **No manual sync**: Eliminates need to manually copy files

## 🔗 Related

Supports the 52-page wiki completed in PR #88