### PR TITLE
Fix wiki Home.md navigation issues

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -147,15 +147,6 @@ This wiki provides a **comprehensive, first-principles approach** to understandi
 ⚠️ **Note**: This section explores speculative applications grounded in cutting-edge research. Content clearly distinguishes established science from theoretical extrapolation.
 
 ### A. Theoretical Framework
-
-### B. THz Technology & Biology
-
-### C. Quantum Biology & Consciousness
-
-### D. Non-Linear Biological Demodulation
-
-### E. Applied Case Study: HRP-Based THz Neuromodulation
-### A. Theoretical Framework
  - [[Hyper-Rotational Physics (HRP) Framework]] - M-theory extension: consciousness-matter coupling via quantum coherence
 
 ### B. THz Technology & Biology
@@ -170,6 +161,7 @@ This wiki provides a **comprehensive, first-principles approach** to understandi
  - [[THz-Resonances-in-Microtubules]] - THz frequency resonances in microtubules
 
 ### D. Non-Linear Biological Demodulation
+ - [[Non-Linear Biological Demodulation]] - Non-linear biological IMD and signal processing
  - [[Intermodulation-Distortion-in-Biology]] - Non-linear biological IMD
  - [[Acoustic-Heterodyning]] - Acoustic heterodyning in tissue
  - [[Frey-Microwave-Auditory-Effect]] - Frey effect: microwave auditory phenomenon
@@ -195,8 +187,6 @@ Chimera is a browser-based DSP simulator implementing:
 
 ### Chimera-Specific Pages
 - [[Signal Chain (End-to-End Processing)]] - Chimera's TX/RX pipeline
-- [Chimera Technical Overview](../docs/chimera_technical_overview.md) - Architecture details
-- [UI Controls Specification](../docs/ui_controls_specification.md) - Interface guide
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes navigation issues in the wiki Home.md page that were present after the Part VIII merge.

## Changes

1. **Remove duplicate Part VIII section headers** - Sections A-E were listed twice (empty headers, then headers with content)
2. **Add missing page link** - Added `[[Non-Linear Biological Demodulation]]` main page link to section D
3. **Remove broken documentation links** - Removed references to deleted files:
   - `docs/chimera_technical_overview.md`
   - `docs/ui_controls_specification.md`

## Impact

- Cleaner, more professional wiki navigation
- No more duplicate headers confusing readers
- All links now functional (broken doc links removed)
- Part VIII section properly structured

## Testing

- Verified all wiki page links are valid
- Confirmed removed doc files no longer exist in repo
- Navigation structure is clean and logical

Fixes navigation issues introduced in #90